### PR TITLE
feat: enhance sales transaction handling with custom exception and additional fields

### DIFF
--- a/app/Exceptions/Sales/SalesTransactionNotFoundException.php
+++ b/app/Exceptions/Sales/SalesTransactionNotFoundException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Exceptions\Sales;
+
+use Exception;
+
+class SalesTransactionNotFoundException extends Exception
+{
+    protected $message = 'Sales transaction not found';
+    protected $code = 404;
+}

--- a/app/Http/Controllers/API/PosController.php
+++ b/app/Http/Controllers/API/PosController.php
@@ -16,7 +16,6 @@ use App\Services\PosService;
 use App\Http\Resources\CartResource;
 use App\Http\Resources\CartItemResource;
 use App\Http\Resources\SalesTransactionResource;
-use App\Models\SalesTransaction;
 
 class PosController extends Controller
 {

--- a/app/Http/Controllers/API/SalesController.php
+++ b/app/Http/Controllers/API/SalesController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\API;
 
+use App\Exceptions\Sales\SalesTransactionNotFoundException;
 use App\Http\Controllers\API\Controller;
 use Illuminate\Http\Request;
 use App\Services\SalesService;
@@ -23,7 +24,7 @@ class SalesController extends Controller
             $search = $request->query('search');
             // Extract specific filters
             $filters = $request->only(['user_id', 'payment_method', 'start_date', 'end_date']);
-            
+
             // Call service
             $result = $this->salesService->getAllSales($search, $filters);
 
@@ -56,15 +57,18 @@ class SalesController extends Controller
                 'success' => true,
                 'data' => new SalesTransactionResource($result)
             ]);
-        } catch (ModelNotFoundException $e) {
-             return response()->json([
-                'success' => false,
-                'message' => 'Sales transaction not found'
-            ], 404);
-        } catch (\Exception $e) {
+        } catch (SalesTransactionNotFoundException $e) {
             return response()->json([
                 'success' => false,
-                'message' => $e->getMessage()
+                'message' => 'Sales transaction not found'
+            ], $e->getCode());
+        } catch (\Exception $e) {
+            \Log::error('Sales Get All Error: ' . $e->getMessage());
+
+            return response()->json([
+                'success' => false,
+                'message' => 'Internal server error',
+                // 'message' => $e->getMessage()
             ], 500);
         }
     }

--- a/app/Http/Controllers/API/SalesController.php
+++ b/app/Http/Controllers/API/SalesController.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Http\Controllers\API;
+
+use App\Http\Controllers\API\Controller;
+use Illuminate\Http\Request;
+use App\Services\SalesService;
+use App\Http\Resources\SalesTransactionResource;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+
+class SalesController extends Controller
+{
+    protected $salesService;
+
+    public function __construct(SalesService $salesService)
+    {
+        $this->salesService = $salesService;
+    }
+
+    public function index(Request $request)
+    {
+        try {
+            $search = $request->query('search');
+            // Extract specific filters
+            $filters = $request->only(['user_id', 'payment_method', 'start_date', 'end_date']);
+            
+            // Call service
+            $result = $this->salesService->getAllSales($search, $filters);
+
+            return response()->json([
+                'success' => true,
+                'data' => SalesTransactionResource::collection($result),
+                'meta' => [
+                    'current_page' => $result->currentPage(),
+                    'per_page' => $result->perPage(),
+                    'total' => $result->total(),
+                    'last_page' => $result->lastPage()
+                ]
+            ]);
+        } catch (\Exception $e) {
+            \Log::error('Sales Get All Error: ' . $e->getMessage());
+
+            return response()->json([
+                'success' => false,
+                'message' => 'Internal server error',
+                // 'error' => $e->getMessage(),
+            ], 500);
+        }
+    }
+
+    public function show($id)
+    {
+        try {
+            $result = $this->salesService->getSalesById($id);
+            return response()->json([
+                'success' => true,
+                'data' => new SalesTransactionResource($result)
+            ]);
+        } catch (ModelNotFoundException $e) {
+             return response()->json([
+                'success' => false,
+                'message' => 'Sales transaction not found'
+            ], 404);
+        } catch (\Exception $e) {
+            return response()->json([
+                'success' => false,
+                'message' => $e->getMessage()
+            ], 500);
+        }
+    }
+}

--- a/app/Http/Resources/SalesTransactionResource.php
+++ b/app/Http/Resources/SalesTransactionResource.php
@@ -26,8 +26,8 @@ class SalesTransactionResource extends JsonResource
             'discount_type' => $this->discount_type,
             'total_amount' => $this->total_amount,
             'payment_method' => $this->payment_method,
+            'created_at' => $this->created_at,
             'sales_item' => SalesItemResource::collection($this->whenLoaded('sales_items'))
-
         ];
     }
 }

--- a/app/Services/SalesService.php
+++ b/app/Services/SalesService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use App\Exceptions\Sales\SalesTransactionNotFoundException;
 use App\Models\SalesTransaction;
 
 class SalesService
@@ -38,6 +39,11 @@ class SalesService
 
     public function getSalesById($id)
     {
-        return SalesTransaction::with(['user', 'sales_items.product'])->findOrFail($id);
+        $salesTransaction = SalesTransaction::with(['user', 'sales_items.product'])->find($id);
+
+        if (!$salesTransaction)
+            throw new SalesTransactionNotFoundException();
+
+        return $salesTransaction;
     }
 }

--- a/app/Services/SalesService.php
+++ b/app/Services/SalesService.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\SalesTransaction;
+
+class SalesService
+{
+
+    public function getAllSales($search = null, $filters = [])
+    {
+        $query = SalesTransaction::with(['user', 'sales_items.product']);
+
+        if ($search) {
+            $query->where('transaction_no', 'LIKE', "%{$search}%");
+        }
+
+        if (!empty($filters)) {
+            if (isset($filters['user_id'])) {
+                $query->where('user_id', $filters['user_id']);
+            }
+            if (isset($filters['payment_method'])) {
+                $query->where('payment_method', $filters['payment_method']);
+            }
+            if (isset($filters['start_date'])) {
+                $query->whereDate('created_at', '>=', $filters['start_date']);
+            }
+            if (isset($filters['end_date'])) {
+                $query->whereDate('created_at', '<=', $filters['end_date']);
+            }
+        }
+
+        // Default sort
+        $query->orderBy('created_at', 'desc');
+
+        return $query->paginate(10)->withQueryString();
+    }
+
+    public function getSalesById($id)
+    {
+        return SalesTransaction::with(['user', 'sales_items.product'])->findOrFail($id);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,20 +1,21 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\API\PosController;
 use App\Http\Controllers\API\AuthController;
 use App\Http\Controllers\API\RoleController;
 use App\Http\Controllers\API\UserController;
 use App\Http\Controllers\API\BrandController;
-use App\Http\Controllers\API\GoogleAuthController;
+use App\Http\Controllers\API\StocksController;
 use App\Http\Controllers\API\ProductController;
 use App\Http\Controllers\API\CategoryController;
 use App\Http\Controllers\API\SupplierController;
 use App\Http\Controllers\API\AttributeController;
 use App\Http\Controllers\API\InventoryController;
+use App\Http\Controllers\API\GoogleAuthController;
 use App\Http\Controllers\API\PermissionController;
 use App\Http\Controllers\API\RolePermissionController;
-use App\Http\Controllers\API\PosController;
-use App\Http\Controllers\API\StocksController;
+use App\Http\Controllers\API\SalesController;
 
 Route::prefix('v1')->group(function () {
     // Public routes (Unauthenticated)
@@ -144,14 +145,14 @@ Route::prefix('v1')->group(function () {
             });
 
             // Stock-movements
-            Route::prefix('stock-movements')->group(function(){
+            Route::prefix('stock-movements')->group(function () {
                 Route::get('/', [StocksController::class, 'showStockMovements']);
                 Route::get('/{id}', [StocksController::class, 'showStockMovementsById']);
                 Route::get('/cv/export', [StocksController::class, 'exportStockMovements']);
             });
 
             // Stock-adjustments
-            Route::prefix('stock-adjustments')->group(function(){
+            Route::prefix('stock-adjustments')->group(function () {
                 Route::get('/', [StocksController::class, 'showStockAdjustments']);
                 Route::get('/{id}', [StocksController::class, 'showStockAdjustmentsById']);
                 Route::get('/cv/export', [StocksController::class, 'exportStockAdjustments']);
@@ -171,6 +172,12 @@ Route::prefix('v1')->group(function () {
                 });
 
                 Route::post('/checkout', [PosController::class, 'checkoutCart'])->middleware('permissions:Create Transaction');
+            });
+
+            //Sales
+            Route::prefix('sales')->group(function () {
+                Route::get('/', [SalesController::class, 'index']);
+                Route::get('/{id}', [SalesController::class, 'show']);
             });
         });
     });


### PR DESCRIPTION
Resolves: #68

## What's new in this PR

### Quick Setup
No specific setup required. Ensure the database is seeded if you want to test with data.
You can verify the new routes by running:
```bash
php artisan route:list | grep sales
```

### TL;DR
Implemented the logic for `GET /api/v1/sales` (list) and `GET /api/v1/sales/{id}` (show) endpoints, enabling retrieval of sales history with search, filtering, and pagination support.

### Summary
This PR finalizes the "Sales Transactions" module API by implementing the necessary Controller and Service logic. It addresses the requirement to list all sales transactions with advanced filtering capabilities (date range, payment method, user) and search functionality. Additionally, it corrects the namespace structure for the `SalesController`.

### Key Features
- **List Sales**: Fetch paginated list of sales transactions.
- **Search**: Search sales by `transaction_no`.
- **Advanced Filtering**:
  - Filter by `user_id` (Cashier/Staff).
  - Filter by `payment_method` (cash, card, gcash, etc.).
  - Filter by Date Range (`start_date`, `end_date`).
- **Detailed View**: Retrieve full details of a specific sales transaction including related items and product details.
- **Optimized Queries**: Uses Eager Loading (`with(['user', 'sales_items.product'])`) to minimize N+1 query issues.

### Technical Changes
- **Refactoring**: Moved `app/Http/Controllers/SalesController.php` to `app/Http/Controllers/API/SalesController.php` to adhere to the project structure.
- **Service Layer**: Implemented `getAllSales()` and `getSalesById()` in `app/Services/SalesService.php`.
- **Controller Logic**: Implemented `index()` and `show()` methods in `SalesController` using `SalesTransactionResource` for standardized JSON responses.
- **Routes**: Added the `/{id}` route to the sales group in `routes/api.php`.

### Checklist
- [x] The code follows the project's coding conventions.
- [x] The endpoints have been manually tested.
- [x] No new migrations were required (uses existing schema).
- [x] API responses match the documentation standards.
