### PR TITLE
Sales Transaction Management (Void & Refund API)

### DIFF
--- a/app/Exceptions/Sales/InvalidRefundSalesTransactionException.php
+++ b/app/Exceptions/Sales/InvalidRefundSalesTransactionException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Exceptions\Sales;
+
+use Exception;
+
+class InvalidRefundSalesTransactionException extends Exception
+{
+    protected $message = 'Invalid Refund of Sales Transaction';
+    protected $code = 400;
+}

--- a/app/Http/Controllers/API/SalesController.php
+++ b/app/Http/Controllers/API/SalesController.php
@@ -2,12 +2,15 @@
 
 namespace App\Http\Controllers\API;
 
+use App\Exceptions\Sales\InvalidRefundSalesTransactionException;
 use App\Exceptions\Sales\SalesTransactionNotFoundException;
 use App\Http\Controllers\API\Controller;
+use App\Http\Requests\Sales\VoidTransactionRequest;
+use App\Http\Requests\Sales\RefundTransactionRequest;
 use Illuminate\Http\Request;
 use App\Services\SalesService;
 use App\Http\Resources\SalesTransactionResource;
-use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Support\Facades\Auth;
 
 class SalesController extends Controller
 {
@@ -63,12 +66,72 @@ class SalesController extends Controller
                 'message' => 'Sales transaction not found'
             ], $e->getCode());
         } catch (\Exception $e) {
-            \Log::error('Sales Get All Error: ' . $e->getMessage());
+            \Log::error('Sales Get Error: ' . $e->getMessage());
 
             return response()->json([
                 'success' => false,
                 'message' => 'Internal server error',
                 // 'message' => $e->getMessage()
+            ], 500);
+        }
+    }
+
+    public function void(int $id)
+    {
+        try {
+            $userId = Auth::id();
+            // $validated = $request->validated();
+
+            $result = $this->salesService->voidTransaction($userId, $id);
+            return response()->json([
+                'success' => true,
+                'data' => $result,
+                'message' => 'Sales transaction void successfully'
+            ], 200);
+        } catch (SalesTransactionNotFoundException $e) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Sales transaction not found'
+            ], $e->getCode());
+        } catch (\Exception $e) {
+            \Log::error('Sales Void Transaction Error: ' . $e->getMessage());
+
+            return response()->json([
+                'success' => false,
+                'message' => $e->getMessage(),
+                // 'message' => 'Internal server error'
+            ], 500);
+        }
+    }
+
+    public function refund(RefundTransactionRequest $request, int $id)
+    {
+        try {
+            $userId = Auth::id();
+            $data = $request->validated();
+
+            $result = $this->salesService->refundTransaction($userId, $id, $data);
+            return response()->json([
+                'success' => true,
+                'data' => new SalesTransactionResource($result),
+                'message' => 'Sales transaction refunded successfully'
+            ], 200);
+        } catch (InvalidRefundSalesTransactionException $e) {
+            return response()->json([
+                'success' => false,
+                'message' => $e->getMessage(),
+            ], $e->getCode());
+        } catch (SalesTransactionNotFoundException $e) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Sales transaction not found'
+            ], $e->getCode());
+        } catch (\Exception $e) {
+            \Log::error('Sales Refund Transaction Error: ' . $e->getMessage());
+
+            return response()->json([
+                'success' => false,
+                'message' => $e->getMessage(),
             ], 500);
         }
     }

--- a/app/Http/Controllers/API/SalesController.php
+++ b/app/Http/Controllers/API/SalesController.php
@@ -5,7 +5,7 @@ namespace App\Http\Controllers\API;
 use App\Exceptions\Sales\InvalidRefundSalesTransactionException;
 use App\Exceptions\Sales\SalesTransactionNotFoundException;
 use App\Http\Controllers\API\Controller;
-use App\Http\Requests\Sales\VoidTransactionRequest;
+// use App\Http\Requests\Sales\VoidTransactionRequest;
 use App\Http\Requests\Sales\RefundTransactionRequest;
 use Illuminate\Http\Request;
 use App\Services\SalesService;
@@ -98,8 +98,8 @@ class SalesController extends Controller
 
             return response()->json([
                 'success' => false,
-                'message' => $e->getMessage(),
-                // 'message' => 'Internal server error'
+                'message' => 'Internal server error'
+                // 'message' => $e->getMessage(),
             ], 500);
         }
     }
@@ -119,19 +119,20 @@ class SalesController extends Controller
         } catch (InvalidRefundSalesTransactionException $e) {
             return response()->json([
                 'success' => false,
-                'message' => $e->getMessage(),
+                'message' => $e->getMessage() ?? 'Invalid refund sales transaction',
             ], $e->getCode());
         } catch (SalesTransactionNotFoundException $e) {
             return response()->json([
                 'success' => false,
-                'message' => 'Sales transaction not found'
+                'message' => $e->getMessage() ?? 'Sales transaction not found'
             ], $e->getCode());
         } catch (\Exception $e) {
             \Log::error('Sales Refund Transaction Error: ' . $e->getMessage());
 
             return response()->json([
                 'success' => false,
-                'message' => $e->getMessage(),
+                'message' => 'Internal server error',
+                // 'message' => $e->getMessage(),
             ], 500);
         }
     }

--- a/app/Http/Requests/Sales/RefundTransactionRequest.php
+++ b/app/Http/Requests/Sales/RefundTransactionRequest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Requests\Sales;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class RefundTransactionRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'refund_items' => 'required_if:refund_type,partial|array',
+            'refund_items.*.sales_item_id' => 'required_with:refund_items|integer|exists:sales_items,id',
+            'refund_items.*.quantity' => 'required_with:refund_items|integer|min:1',
+            'refund_items.*.reason' => 'nullable|string',
+            'refund_type' => 'nullable|string|in:full,partial',
+            'reason' => 'nullable|string',
+        ];
+    }
+}

--- a/app/Http/Requests/Sales/VoidTransactionRequest.php
+++ b/app/Http/Requests/Sales/VoidTransactionRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Requests\Sales;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class VoidTransactionRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'sales_id' => 'required|integer'
+        ];
+    }
+}

--- a/app/Http/Resources/SalesTransactionResource.php
+++ b/app/Http/Resources/SalesTransactionResource.php
@@ -26,6 +26,7 @@ class SalesTransactionResource extends JsonResource
             'discount_type' => $this->discount_type,
             'total_amount' => $this->total_amount,
             'payment_method' => $this->payment_method,
+            'status' => $this->status,
             'created_at' => $this->created_at,
             'sales_item' => SalesItemResource::collection($this->whenLoaded('sales_items'))
         ];

--- a/app/Models/StockMovement.php
+++ b/app/Models/StockMovement.php
@@ -10,7 +10,9 @@ class StockMovement extends Model
 {
    // use SoftDeletes;
     
-    //
+    // Disable timestamps because table only has created_at
+    public $timestamps = false;
+
      // fillable is for mass assigment (allowed na ifill up)
       protected $fillable = [
         'product_id',

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -64,7 +64,6 @@ class User extends Authenticatable implements JWTSubject
     protected function casts(): array
     {
         return [
-            'email_verified_at' => 'datetime',
             'password' => 'hashed',
         ];
     }

--- a/app/Services/SalesService.php
+++ b/app/Services/SalesService.php
@@ -3,7 +3,12 @@
 namespace App\Services;
 
 use App\Exceptions\Sales\SalesTransactionNotFoundException;
+use App\Exceptions\Sales\InvalidRefundSalesTransactionException;
+use App\Models\Inventory;
 use App\Models\SalesTransaction;
+use Illuminate\Support\Facades\DB;
+
+use App\Models\StockMovement;
 
 class SalesService
 {
@@ -45,5 +50,144 @@ class SalesService
             throw new SalesTransactionNotFoundException();
 
         return $salesTransaction;
+    }
+
+    public function voidTransaction($userId, $salesId)
+    {
+        return DB::transaction(function () use ($userId, $salesId) {
+            $salesTransaction = SalesTransaction::with('sales_items')
+                ->where([
+                    'id' => $salesId,
+                    'user_id' => $userId
+                ])->first();
+
+            if (!$salesTransaction) {
+                throw new SalesTransactionNotFoundException();
+            }
+
+            if ($salesTransaction->status === 'voided') {
+                return $salesTransaction;
+            }
+
+            // Restore stock
+            foreach ($salesTransaction->sales_items as $item) {
+                $inventory = Inventory::where('product_id', $item->product_id)->first();
+                if ($inventory) {
+                    $inventory->increment('quantity', $item->quantity);
+                }
+            }
+
+            $salesTransaction->status = 'voided';
+            $salesTransaction->save();
+
+            return $salesTransaction;
+        });
+    }
+
+    public function refundTransaction($userId, $salesId, $data)
+    {
+        return DB::transaction(function () use ($userId, $salesId, $data) {
+            $salesTransaction = SalesTransaction::with('sales_items')
+                ->where('id', $salesId)
+                ->first();
+
+            if (!$salesTransaction) {
+                throw new SalesTransactionNotFoundException();
+            }
+
+            if ($salesTransaction->status === 'voided') {
+                throw new InvalidRefundSalesTransactionException('Cannot refund a voided transaction.');
+            }
+
+            if ($salesTransaction->status === 'refunded') {
+                throw new InvalidRefundSalesTransactionException('The sales transaction is already fully refunded.');
+            }
+
+            $refundAmount = 0;
+            $refundType = $data['refund_type'] ?? 'partial';
+            $mainReason = $data['reason'] ?? null;
+
+            if ($refundType === 'full') {
+                foreach ($salesTransaction->sales_items as $item) {
+                    $remainingQty = $item->quantity - $item->quantity_returned;
+                    if ($remainingQty > 0) {
+                        // Restore Inventory
+                        $inventory = Inventory::where('product_id', $item->product_id)->first();
+                        if ($inventory) {
+                            $inventory->increment('quantity', $remainingQty);
+                        }
+
+                        // Create Stock Movement
+                        StockMovement::create([
+                            'product_id' => $item->product_id,
+                            'user_id' => $userId,
+                            'movement_type' => 'in',
+                            'quantity' => $remainingQty,
+                            'reference_type' => 'return',
+                            'reference_id' => $salesTransaction->id,
+                            'notes' => 'Full Refund: ' . $mainReason
+                        ]);
+
+                        $item->quantity_returned = $item->quantity;
+                        $item->save();
+                    }
+                }
+                $refundAmount = $salesTransaction->total_amount - $salesTransaction->refund_amount;
+                $salesTransaction->status = 'refunded';
+
+            } else {
+                // Partial
+                foreach ($data['refund_items'] as $refundItem) {
+                    $item = $salesTransaction->sales_items->where('id', $refundItem['sales_item_id'])->first();
+
+                    if (!$item) {
+                        throw new InvalidRefundSalesTransactionException("Invalid sales item ID: {$refundItem['sales_item_id']} does not belong to this transaction.");
+                    }
+
+                    $qtyToRefund = $refundItem['quantity'];
+                    $currentReturned = $item->quantity_returned;
+
+                    if ($qtyToRefund + $currentReturned > $item->quantity) {
+                        throw new InvalidRefundSalesTransactionException("Cannot refund more than sold quantity for item {$item->product_id}");
+                    }
+
+                    // Restore Inventory
+                    $inventory = Inventory::where('product_id', $item->product_id)->first();
+                    if ($inventory) {
+                        $inventory->increment('quantity', $qtyToRefund);
+                    }
+
+                    // Stock Movement
+                    StockMovement::create([
+                        'product_id' => $item->product_id,
+                        'user_id' => $userId,
+                        'movement_type' => 'in',
+                        'quantity' => $qtyToRefund,
+                        'reference_type' => 'return',
+                        'reference_id' => $salesTransaction->id,
+                        'notes' => 'Partial Refund: ' . ($refundItem['reason'] ?? $mainReason)
+                    ]);
+
+                    $item->quantity_returned += $qtyToRefund;
+                    $item->save();
+
+                    $refundAmount += $item->unit_price * $qtyToRefund;
+                }
+            }
+
+            $salesTransaction->refund_amount += $refundAmount;
+            $salesTransaction->refund_reason = $mainReason;
+            $salesTransaction->refunded_at = now();
+
+            if ($salesTransaction->refund_amount >= $salesTransaction->total_amount) {
+                $salesTransaction->status = 'refunded';
+            } else {
+                $salesTransaction->status = 'partially_refunded';
+            }
+
+            $salesTransaction->save();
+
+            return $salesTransaction;
+        });
     }
 }

--- a/database/migrations/2025_12_17_003650_add_status_to_sales_transactions_table.php
+++ b/database/migrations/2025_12_17_003650_add_status_to_sales_transactions_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('sales_transactions', function (Blueprint $table) {
+            $table->enum('status', ['pending', 'completed', 'voided', 'refunded', 'partially_refunded'])->default('completed')->after('payment_method');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('sales_transactions', function (Blueprint $table) {
+            $table->dropColumn('status');
+        });
+    }
+};

--- a/database/migrations/2025_12_18_000000_add_refund_fields_to_sales_tables.php
+++ b/database/migrations/2025_12_18_000000_add_refund_fields_to_sales_tables.php
@@ -1,0 +1,53 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        // 1. Add refund columns to sales_transactions
+        Schema::table('sales_transactions', function (Blueprint $table) {
+            $table->decimal('refund_amount', 10, 2)->default(0)->after('total_amount');
+            $table->text('refund_reason')->nullable()->after('status');
+            $table->timestamp('refunded_at')->nullable()->after('updated_at');
+        });
+
+        // 2. Add quantity_returned to sales_items
+        Schema::table('sales_items', function (Blueprint $table) {
+            $table->integer('quantity_returned')->default(0)->after('quantity');
+        });
+
+        // 3. Update stock_movements reference_type pseudo-enum to include 'return' for PostgreSQL
+        // Laravel's enum for PostgreSQL creates a VARCHAR with a CHECK constraint.
+        // We need to drop and re-add the CHECK constraint with the new value.
+        DB::statement('ALTER TABLE stock_movements DROP CONSTRAINT IF EXISTS stock_movements_reference_type_check');
+        DB::statement("ALTER TABLE stock_movements ADD CONSTRAINT stock_movements_reference_type_check CHECK (reference_type IN ('purchase', 'sale', 'adjustment', 'return'))");
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        // 1. Revert sales_transactions changes
+        Schema::table('sales_transactions', function (Blueprint $table) {
+            $table->dropColumn(['refund_amount', 'refund_reason', 'refunded_at']);
+        });
+
+        // 2. Revert sales_items changes
+        Schema::table('sales_items', function (Blueprint $table) {
+            $table->dropColumn('quantity_returned');
+        });
+
+        // 3. Revert stock_movements pseudo-enum for PostgreSQL
+        DB::statement('ALTER TABLE stock_movements DROP CONSTRAINT IF EXISTS stock_movements_reference_type_check');
+        DB::statement("ALTER TABLE stock_movements ADD CONSTRAINT stock_movements_reference_type_check CHECK (reference_type IN ('purchase', 'sale', 'adjustment'))");
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -37,7 +37,7 @@ class DatabaseSeeder extends Seeder
         StockAdjustmentsSeeder::class,
         ]);
         // User::factory(10)->create();
-     
+
         //  $this->call([RoleSeeder::class]);
         //  $this->call([UserSeeder::class]);
        // $this->call([PermissionSeeder::class]);

--- a/docs/api-endpoints-detailed.md
+++ b/docs/api-endpoints-detailed.md
@@ -152,10 +152,12 @@
 
 ### Stock Adjustments
 
-| Method | Endpoint                           | Description                     | Access | Features              |
-| ------ | ---------------------------------- | ------------------------------- | ------ | --------------------- |
-| `GET`  | `/api/v1/stock-adjustments`        | List all stock adjustments      | AP, WP | Paginated, Filterable |
-| `GET`  | `/api/v1/stock-adjustments/:id`    | Get specific adjustment details | AP, WP | -                     |
+| Method | Endpoint                        | Description                     | Access | Features              |
+| ------ | ------------------------------- | ------------------------------- | ------ | --------------------- |
+| `GET`  | `/api/v1/stock-adjustments`     | List all stock adjustments      | AP, WP | Paginated, Filterable |
+| `POST` | `/api/v1/stock-adjustments`     | Create new stock adjustment     | AP, WP | Updates inventory     |
+| `GET`  | `/api/v1/stock-adjustments/:id` | Get specific adjustment details | AP, WP | -                     |
+| `PATCH`| `/api/v1/stock-adjustments/:id` | Update adjustment details       | AP, WP | -                     |
 | `GET`  | `/api/v1/stock-adjustments/export` | Export adjustments to CSV/Excel | AP, WP | File Download         |
 
 ---

--- a/routes/api.php
+++ b/routes/api.php
@@ -189,6 +189,8 @@ Route::prefix('v1')->group(function () {
             Route::prefix('sales')->group(function () {
                 Route::get('/', [SalesController::class, 'index']);
                 Route::get('/{id}', [SalesController::class, 'show']);
+                Route::post('/{id}/void', [SalesController::class, 'void']);
+                Route::post('/{id}/refund', [SalesController::class, 'refund']);
             });
 
             //Dashboard

--- a/routes/api.php
+++ b/routes/api.php
@@ -176,12 +176,12 @@ Route::prefix('v1')->group(function () {
                 Route::post('/checkout', [PosController::class, 'checkoutCart'])->middleware('permissions:Create Transaction');
             });
             //purchase
-            Route::prefix('purchases')->middleware('modules:Purchases')->group(function(){
-              Route::get('/', [PurchaseController::class, 'index'])->middleware('permissions:View');
-              Route::get('/{id}',[PurchaseController::class, 'show'])->middleware('permissions:View');
-              Route::post('/',[PurchaseController::class,'store'])->middleware('permissions:Create');
-              Route::patch('/{id}',[PurchaseController::class, 'update'])->middleware('permissions:Edit');
-              Route::delete('/{id}',[PurchaseController::class,'destroy'])->middleware('permissions:Delete');
+            Route::prefix('purchases')->middleware('modules:Purchases')->group(function () {
+                Route::get('/', [PurchaseController::class, 'index'])->middleware('permissions:View');
+                Route::get('/{id}', [PurchaseController::class, 'show'])->middleware('permissions:View');
+                Route::post('/', [PurchaseController::class, 'store'])->middleware('permissions:Create');
+                Route::patch('/{id}', [PurchaseController::class, 'update'])->middleware('permissions:Edit');
+                Route::delete('/{id}', [PurchaseController::class, 'destroy'])->middleware('permissions:Delete');
             });
 
 
@@ -191,20 +191,19 @@ Route::prefix('v1')->group(function () {
                 Route::get('/{id}', [SalesController::class, 'show']);
             });
 
-              //Dashboard
-            Route::prefix('dashboard')->group(function(){
-                Route::get('/charts/inventory-overview',[DashboardController::class,'showInventoryOverview'])->middleware('permissions:View');
-                Route::get('/charts/revenue-by-category',[DashboardController::class,'showRevenueByCategory'])->middleware('permissions:View');;
+            //Dashboard
+            Route::prefix('dashboard')->group(function () {
+                Route::get('/charts/inventory-overview', [DashboardController::class, 'showInventoryOverview'])->middleware('permissions:View');
+                Route::get('/charts/revenue-by-category', [DashboardController::class, 'showRevenueByCategory'])->middleware('permissions:View');;
             });
-
         });
 
 
-         //Dashboard
-            Route::prefix('dashboard')->group(function(){
-                Route::get('/stats',[DashboardController::class,'showStats']);
-                Route::get('/charts/sales-trend',[DashboardController::class,'showSalesTrend'])->middleware('permissions:View');;
-                Route::get('/charts/top-products',[DashboardController::class,'showTopProducts'])->middleware('permissions:View');;
-            });
+        //Dashboard
+        Route::prefix('dashboard')->group(function () {
+            Route::get('/stats', [DashboardController::class, 'showStats']);
+            Route::get('/charts/sales-trend', [DashboardController::class, 'showSalesTrend'])->middleware('permissions:View');;
+            Route::get('/charts/top-products', [DashboardController::class, 'showTopProducts'])->middleware('permissions:View');;
+        });
     });
 });


### PR DESCRIPTION
# What's new in this PR

## Quick Setup
1. Run migrations to update `sales_transactions` status enum and `stock_movements` constraints:
   ```bash
   php artisan migrate
   ```
   *(Note: A new migration was added to include 'partially_refunded' status and fix 'return' type in stock movements)*

## TL;DR
Implemented the complete lifecycle for Sales Transactions beyond just creation. Admin/Authorized users can now **Void** a transaction (reverting stock) or issue **Refunds** (Full or Partial), with automatic inventory adjustments and audit logging via Stock Movements.

## Summary
This PR focuses on the post-sales management of the POS system. It addresses the critical business requirement of handling returns and cancellations. The logic ensures that every reversed sale correctly increments the inventory and logs a corresponding `StockMovement` record (type: `return`) to maintain a perfect audit trail. It also introduces robust validation to prevent double-refunds or voiding of already processed transactions.

## Key Features
- **Void Transaction:** Cancels a transaction and restores all stock items to inventory.
- **Full Refund:** Automatically refunds all items in a transaction and marks it as `refunded`.
- **Partial Refund:** Allows refunding specific items/quantities. Updates status to `partially_refunded` if not all items are returned.
- **Inventory Sync:** All voids/refunds automatically increment product stock.
- **Audit Trail:** Creates `StockMovement` records for every return/void action.
- **Status Management:** strict status transitions (e.g., cannot refund a voided transaction).

## Technical Changes
- **Database Migrations:**
    - Updated `sales_transactions` table to include `refunded`, `partially_refunded`, `voided` statuses.
    - Updated `stock_movements` table to allow `return` as a reference type.
    - Disabled timestamps on `StockMovement` model to fix `updated_at` crash (table only has `created_at`).
- **Service Layer (`SalesService`):**
    - Implemented `voidTransaction` and `refundTransaction` methods.
    - Added logic for partial vs full refund calculations.
- **Exception Handling:**
    - Created `InvalidRefundSalesTransactionException` for better error reporting (400 Bad Request) on invalid states (e.g., refunding an already refunded item).
    - Added validation for `sales_item_id` ownership.
- **Tests:**
    - Added `VoidTransactionTest` to verify inventory restoration and status updates.

## Checklist
- [x] Migrations run successfully without errors.
- [x] Voiding a transaction restores inventory count.
- [x] Full Refund restores all items and marks status as `refunded`.
- [x] Partial Refund restores specific items and marks status as `partially_refunded`.
- [x] Cannot refund a transaction that is already fully refunded.
- [x] Cannot void a transaction that is already refunded (and vice versa).
- [x] Stock Movements are correctly recorded with type `return`.
