### PR TITLE
fix error

### DIFF
--- a/app/Http/Controllers/API/StocksController.php
+++ b/app/Http/Controllers/API/StocksController.php
@@ -43,12 +43,8 @@ class StocksController extends Controller
         }
     }
 
-    /**
-     * Display the specified stock adjustment.
-     *
-     * @param int $id
-     * @return \Illuminate\Http\JsonResponse
-     */
+   // Display the specified stock adjustment.
+
     public function showStockAdjustmentsById($id)
     {
         try {
@@ -66,12 +62,8 @@ class StocksController extends Controller
         }
     }
 
-    /**
-     * Export stock adjustments to a file.
-     *
-     * @param Request $request
-     * @return \Illuminate\Http\JsonResponse
-     */
+    // Export stock adjustments to a file.
+ 
     public function exportStockAdjustments()
     {
         try {
@@ -82,16 +74,13 @@ class StocksController extends Controller
         }
     }
 
-    /**
-     * Display a listing of the stock movements.
-     *
-     * @param Request $request
-     * @return \Illuminate\Http\JsonResponse
-     */
+    // Display a listing of the stock movements.
+    
     public function showStockMovements(Request $request)
     {
         try {
-        $result = $this->stocksService->getStockMovements($request->all());
+            $search = $request->query('search', null);
+        $result = $this->stocksService->getStockMovements($search);
             //  return StockMovementResource::collection($movements)->response();
             return response()->json(
                 [
@@ -110,17 +99,13 @@ class StocksController extends Controller
         }
     }
 
-    /**
-     * Display the specified stock movement.
-     *
-     * @param int $id
-     * @return \Illuminate\Http\JsonResponse
-     */
+  // Display the specified stock movement.
+   
     public function showStockMovementsById(int $id)
     {
         try {
             $result = $this->stocksService->showStockMovementsById($id);
-            //return (new StockMovementResource($movement))->response();
+           
 
             return response()->json([
                 'success' => true,
@@ -132,13 +117,8 @@ class StocksController extends Controller
             return response()->json(['message' => 'An unexpected error occurred.'], 500);
         }
     }
+// Export stock movements to a file.
 
-    /**
-     * Export stock movements to a file.
-     *
-        * @param Request $request
-     * @return \Illuminate\Http\JsonResponse
-     */
     public function exportStockMovements(Request $request)
     {
         try {

--- a/app/Services/StocksService.php
+++ b/app/Services/StocksService.php
@@ -16,9 +16,8 @@ class StocksService
 
     if ($search) {
         $query->where(function ($q) use ($search) {
-            $q->where('reason', 'LIKE', "%{$search}%")
-              ->orWhere('user_id', 'LIKE', "%{$search}%")
-              ->orWhereDate('created_at', $search);
+            $q->where('reason', 'ILIKE', "%{$search}%")
+              ->orWhere('user_id', 'ILIKE', "%{$search}%");
         });
     }
 
@@ -81,24 +80,23 @@ class StocksService
 
             // product name
             $q->whereHas('product', function ($p) use ($search) {
-                $p->where('name', 'LIKE', "%{$search}%");
+                $p->where('name', 'ILIKE', "%{$search}%");
             })
 
             // brand name
             ->orWhereHas('product.brand', function ($b) use ($search) {
-                $b->where('name', 'LIKE', "%{$search}%");
+                $b->where('name', 'ILIKE', "%{$search}%");
             })
 
             // user name
             ->orWhereHas('user', function ($u) use ($search) {
-                $u->where('name', 'LIKE', "%{$search}%");
+                $u->where('name', 'ILIKE', "%{$search}%");
             })
 
             // movement type (in / out / adjustment)
-            ->orWhere('movement_type', 'LIKE', "%{$search}%")
+            ->orWhere('movement_type', 'ILIKE', "%{$search}%");
 
-            // date search (YYYY-MM-DD)
-            ->orWhereDate('created_at', $search);
+           
         });
     }
 


### PR DESCRIPTION
- PR TITLE
Fix: Case-insensitive search for stocks and simplified search query

- What's new in this PR

    - Quick Setup
    None

    - TL;DR
    Fixed a bug where stock searches were case-sensitive. Search for stock adjustments and movements is now case-insensitive.

    - Summary
    This PR addresses a bug in the stock searching functionality. Previously, searches for stock adjustments and stock movements were case-sensitive, which led to a poor user experience. This has been resolved by using `ILIKE` for searches, making them case-insensitive. Additionally, the date search functionality, which was causing issues, has been temporarily removed from the stock adjustment and movement searches. The controller has also been updated to handle the search parameter correctly.

    - Key Features
        - Case-insensitive search for stock adjustments.
        - Case-insensitive search for stock movements.

    - Technical Changes
        - Modified `app/Services/StocksService.php`:
            - Changed `LIKE` to `ILIKE` in `showStockAdjustments` and `getStockMovements` for case-insensitive searching.
            - Removed `orWhereDate` from the search queries in both methods.
        - Modified `app/Http/Controllers/API/StocksController.php`:
            - Updated `showStockMovements` to correctly retrieve and pass the `search` query parameter.
            - Cleaned up comments, converting docblocks to single-line comments.

    - Checklist
        - [x] Code follows the project's coding standards.
        - [ ] Tests have been added or updated to cover the changes.
        - [x] The code has been tested manually.
        - [ ] The documentation has been updated.