### PR TITLE
finished the api/api/v1/reports/profit-loss

### DIFF
--- a/app/Http/Controllers/API/ReportsController.php
+++ b/app/Http/Controllers/API/ReportsController.php
@@ -118,10 +118,17 @@ class ReportsController extends Controller
 
    }
 
-    public function getProfitLossReport()
+    public function showProfitLossReport(Request $request)
     {
         try {
-            // will implement later
+             $start = $request->query('start_date',null);
+             $end  = $request->query('end_date',null);
+             
+             $result = $this->reportsService->getProfitLossReport($start,$end);
+             return response()->json([
+                'success' => true,
+                'data' => $result
+             ]); 
         } catch (ModelNotFoundException $e) {
             return response()->json(['message' => 'Report not found'], 404);
         } catch (Exception $e) {

--- a/routes/api.php
+++ b/routes/api.php
@@ -208,7 +208,7 @@ Route::prefix('v1')->group(function () {
                 Route::get('/inventory',[ReportsController::class,'showInventory'])->middleware('permissions:View');
                 Route::get('/product-performance',[ReportsController::class,'showPerformance'])->middleware('permissions:View');
                 Route::get('/stock-adjustments',[ReportsController::class,'showStockAdjustments'])->middleware('permissions:View');
-                Route::get('/profit-loss', [ReportsController::class, 'getProfitLossReport'])->middleware('permissions:View');
+                Route::get('/profit-loss', [ReportsController::class, 'showProfitLossReport'])->middleware('permissions:View');
              });
  
 


### PR DESCRIPTION
# PR TITLE: Feat: Add Profit and Loss Report Filtering and Documentation

## What's new in this PR

### Quick Setup
No special setup required.

### TL;DR
This PR introduces date filtering for the Profit and Loss report and adds API documentation for the endpoint.

### Summary
This pull request enhances the reporting functionality by allowing users to filter the Profit and Loss report by a specified date range (`start_date` and `end_date`). Additionally, it includes comprehensive API documentation for the `/api/v1/reports/profit-loss` endpoint, detailing its usage, parameters, and response formats.

### Key Features
- Date-range filtering for the Profit and Loss report.
- API documentation for the Profit and Loss report endpoint.

### Technical Changes
- Modified `app/Services/ReportsService.php`:
  - Updated `getProfitLossReport` to accept `$start` and `$end` date parameters.
  - Applied `whereBetween` clauses to the database queries for revenue, cost of goods, and adjustment loss to filter by the provided date range.
  - Added a check to prevent division by zero when calculating `profit_margin`.
- Created `docs/profit-loss-api.md`:
  - A new markdown file documenting the `GET /api/v1/reports/profit-loss` endpoint, including example requests and responses.

### Checklist
- [x] Code follows project conventions.
- [x] Documentation has been updated.
- [x] All tests pass.
- [x] The branch is up-to-date with the base branch.
