### PR TITLE
Addition for seeder to add permission earlier to make it more easier …

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -20,6 +20,7 @@ class DatabaseSeeder extends Seeder
         // 1. Core Foundations (No dependencies)
         RoleSeeder::class,
         PermissionSeeder::class,
+        RolePermissionSeeder::class,
         CategorySeeder::class,
         BrandSeeder::class,
         SupplierSeeder::class, // <-- CRITICAL: Must be before Purchase Orders

--- a/database/seeders/RolePermissionSeeder.php
+++ b/database/seeders/RolePermissionSeeder.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Role;
+use App\Models\Permission;
+
+class RolePermissionSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        // Get all permissions
+        $permissions = Permission::all();
+
+        // Get the superadmin role
+        $superAdminRole = Role::where('role_name', 'superadmin')->first();
+
+        // Assign all permissions to the superadmin role
+        if ($superAdminRole) {
+            $superAdminRole->permissions()->sync($permissions->pluck('id'));
+        }
+    }
+}


### PR DESCRIPTION
### Quick Setup

- Run `php artisan db:seed` to populate the database with the new `RolePermissionSeeder`.

### TL;DR

This PR introduces a new database seeder, `RolePermissionSeeder`, to automatically assign all permissions to the `superadmin` role. This eliminates the need for manual permission assignment after setting up the application.

### Summary

Previously, new installations of the application required a manual API call to grant the `superadmin` role the necessary permissions to access all modules. This PR automates this process by introducing a new database seeder that runs after the `RoleSeeder` and `PermissionSeeder`.

### Key Features

-   **`RolePermissionSeeder`:** A new seeder that assigns all existing permissions to the `superadmin` role.
-   **Updated `DatabaseSeeder`:** The `DatabaseSeeder` is updated to call the new `RolePermissionSeeder`, ensuring that the permissions are seeded automatically.

### Technical Changes

-   Created `database/seeders/RolePermissionSeeder.php`.
-   Updated `database/seeders/DatabaseSeeder.php` to call the new seeder.

### Checklist

-   [x] The `superadmin` role now has all permissions by default.
-   [x] Manual permission assignment for the `superadmin` role is no longer necessary.
-   [x] The application is in a consistent state after running `php artisan db:seed`.
