### PR TITLE
feat(settings): Implement update user theme endpoint

### DIFF
--- a/app/Http/Controllers/API/ProfileController.php
+++ b/app/Http/Controllers/API/ProfileController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\API;
 
 use App\Exceptions\Auth\UserNotFoundException;
 use App\Http\Requests\Settings\Profile\UpdateProfileRequest;
+use App\Http\Requests\Settings\Profile\UpdateThemeRequest;
 use App\Http\Requests\Settings\Security\ChangePasswordRequest;
 use App\Http\Resources\ProfileResource;
 use App\Services\UserService;
@@ -97,6 +98,34 @@ class ProfileController
             ], $e->getCode());
         } catch (\Exception $e) {
             \Log::error('Settings Profile Password [PATCH] Error: ' . $e->getMessage(), [
+                'user_id' => $userId,
+                'trace' => $e->getTraceAsString(),
+            ]);
+
+            return response()->json([
+                'success' => false,
+                'message' => 'Internal server error'
+            ], 500);
+        }
+    }
+
+    public function updateTheme(UpdateThemeRequest $request)
+    {
+        $userId = Auth::id();
+        try {
+            $this->userService->updateThemeById($userId, $request->validated());
+
+            return response()->json([
+                'success' => true,
+                'message' => 'Theme updated successfully'
+            ]);
+        } catch (UserNotFoundException $e) {
+            return response()->json([
+                'success' => false,
+                'message' => $e->getMessage(),
+            ], $e->getCode());
+        } catch (\Exception $e) {
+            \Log::error('Settings Theme [PATCH] Error: ' . $e->getMessage(), [
                 'user_id' => $userId,
                 'trace' => $e->getTraceAsString(),
             ]);

--- a/app/Http/Requests/Settings/Profile/UpdateThemeRequest.php
+++ b/app/Http/Requests/Settings/Profile/UpdateThemeRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Requests\Settings\Profile;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateThemeRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'theme' => ['required', 'string', 'in:light,dark'],
+        ];
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -43,7 +43,8 @@ class User extends Authenticatable implements JWTSubject
         'password',
         'first_name',
         'last_name',
-        'google_id'
+        'google_id',
+        'theme'
     ];
 
     /**

--- a/app/Services/UserService.php
+++ b/app/Services/UserService.php
@@ -143,4 +143,16 @@ class UserService
 
         return true;
     }
+
+    public function updateThemeById(int $id, array $fields)
+    {
+        $user = User::find($id);
+        if (!$user) throw new UserNotFoundException($id, 'id');
+
+        $user->update([
+            'theme' => $fields['theme']
+        ]);
+
+        return $user;
+    }
 }

--- a/database/migrations/2026_01_13_055814_add_theme_to_users_table.php
+++ b/database/migrations/2026_01_13_055814_add_theme_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('theme')->default('light')->after('google_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('theme');
+        });
+    }
+};

--- a/docs/api-endpoints-detailed.md
+++ b/docs/api-endpoints-detailed.md
@@ -282,13 +282,13 @@
 | Method | Endpoint                          | Description              | Access | Features        |
 | ------ | --------------------------------- | ------------------------ | ------ | --------------- |
 | `GET`  | `/api/v1/settings/profile`        | Get current user profile | Auth   | -               |
-| `PUT`  | `/api/v1/settings/profile`        | Update user profile      | Auth   | -               |
-| `PUT`  | `/api/v1/settings/password`       | Change user password     | Auth   | -               |
-| `PUT`  | `/api/v1/settings/theme`          | Update theme preference  | Auth   | Light/Dark mode |
+| `PATCH`  | `/api/v1/settings/profile`        | Update user profile      | Auth   | -               |
+| `PATCH`  | `/api/v1/settings/password`       | Change user password     | Auth   | -               |
+| `PATCH`  | `/api/v1/settings/theme`          | Update theme preference  | Auth   | Light/Dark mode |
 | `GET`  | `/api/v1/settings/system`         | Get global system config | AP, WP | -               |
-| `PUT`  | `/api/v1/settings/system`         | Update global config     | AP, WP | -               |
+| `PATCH`  | `/api/v1/settings/system`         | Update global config     | AP, WP | -               |
 | `GET`  | `/api/v1/settings/system/backup`  | Create system backup     | AP, WP | File Download   |
-| `PUT`  | `/api/v1/settings/system/restore` | Restore from backup      | AP, WP | File Upload     |
+| `PATCH`  | `/api/v1/settings/system/restore` | Restore from backup      | AP, WP | File Upload     |
 
 ---
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -226,6 +226,7 @@ Route::prefix('v1')->group(function () {
             Route::get('/profile', [ProfileController::class, 'showProfile']);
             Route::patch('/profile', [ProfileController::class, 'updateProfile']);
             Route::patch('/password', [ProfileController::class, 'updatePassword']);
+            Route::patch('/theme', [ProfileController::class, 'updateTheme']);
         });
     });
 });


### PR DESCRIPTION
Resolves: #98 

# What's new in this PR

### Quick Setup
1.  **Backend:** Run migrations to add the `theme` column to the `users` table.
    ```bash
    php artisan migrate
    ```

### TL;DR
Added a `PATCH /api/v1/settings/theme` endpoint to allow users to toggle between "light" and "dark" modes. This preference is now stored in the database for cross-device persistence.

### Summary
This PR addresses the need for a persistent theme setting for users. Instead of relying on local storage, which limits the preference to a single device, we have extended the `users` table to include a `theme` column. A new API endpoint has been exposed to allow authenticated users to update this setting securely.

### Key Features
*   **New API Endpoint:** `PATCH /api/v1/settings/theme`
*   **Data Persistence:** Theme preference is stored in the database (`users` table).
*   **Validation:** Accepts only 'light' or 'dark' values.
*   **Default Value:** New users default to 'light' theme.

### Technical Changes
*   **Migration:** Created `2026_01_13_055814_add_theme_to_users_table.php` to add the string column `theme`.
*   **Model:** Updated `App\Models\User` to include `theme` in `$fillable`.
*   **Request:** Created `App\Http\Requests\Settings\Profile\UpdateThemeRequest` for input validation.
*   **Service:** Added `updateThemeById` logic to `App\Services\UserService`.
*   **Controller:** Added `updateTheme` method to `App\Http\Controllers\API\ProfileController`.
*   **Routes:** Registered the new route in `routes/api.php` under the `settings` prefix.

### Checklist
- [x] Migrations created and tested.
- [x] API endpoint implemented and routed.
- [x] Request validation (in:light,dark) added.
- [x] Service layer logic implemented.
- [x] User model updated.
