### PR TITLE
Google Authentication 500 Error

### DIFF
--- a/app/Services/GoogleAuthService.php
+++ b/app/Services/GoogleAuthService.php
@@ -15,7 +15,7 @@ class GoogleAuthService
 {
     private Google_Client $googleClient;
     protected ActivityLogService $activityLog;
-    public function __construct()
+    public function __construct(ActivityLogService $activityLog)
     {
         $this->googleClient = new Google_Client([
             'client_id' => config('services.google.client_id')


### PR DESCRIPTION
What's new in this PR:

- Quick Setup
    - No specific setup needed. This is a backend-only fix.

- TL;DR
    - Resolved a 500 Internal Server Error occurring during Google authentication due to an "Undefined variable $activityLog" in `GoogleAuthService.php`. The `ActivityLogService` is now correctly injected.

- Summary
    - This PR addresses a critical bug that prevented successful Google authentication. Users were encountering a 500 Internal Server Error because the `GoogleAuthService` attempted to use `$activityLog` without it being properly initialized. This occurred in the constructor where `ActivityLogService` was not injected, leading to an "Undefined variable" error when an attempt was made to log the authentication event.

- Key Features
    - Restores full functionality for Google login.
    - Ensures proper logging of Google authentication events.

- Technical Changes
    - **`pacadaworkz-motomedic-ims-api/app/Services/GoogleAuthService.php`**:
        - Modified the `__construct` method to properly inject the `ActivityLogService` dependency.
        - Assigned the injected `ActivityLogService` instance to the `$this->activityLog` property, resolving the "Undefined variable" error.

- Checklist
    - [x] Confirmed Google authentication flow is working.
    - [x] Verified that activity logs are correctly recorded for Google logins.
    - [x] Ensured no new errors or regressions were introduced.


this closes #111 