### PR TITLE
refactor: improve low stock count logic in DashboardService and ReportsService

### DIFF
--- a/app/Services/ReportsService.php
+++ b/app/Services/ReportsService.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace App\Services;
+
 use App\Models\SalesItem;
 use App\Models\SalesTransaction;
 use App\Models\PurchaseItem;
@@ -9,204 +10,215 @@ use App\Models\Product;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\DB;
 use App\Services\ReportCSVService;
+
 class ReportsService
 {
- 
+
     protected $reportCSVService;
- 
- public function __construct(ReportCSVService $reportCSVService){
-     $this->reportCSVService = $reportCSVService;
- }
 
- // sales report
-    public function getSalesReport($start = null,$end = null){
-   
-
-  // Set start date
-    if (!$start) {
-        $start = DB::table('sales_transactions')->min('created_at');
-        $start = $start
-            ? Carbon::parse($start)->startOfDay()
-            : Carbon::today()->startOfDay();
-    } else {
-        $start = Carbon::parse($start)->startOfDay();
+    public function __construct(ReportCSVService $reportCSVService)
+    {
+        $this->reportCSVService = $reportCSVService;
     }
 
-    // Set end date
-    $end = $end
-        ? Carbon::parse($end)->endOfDay()
-        : Carbon::today()->endOfDay();
+    // sales report
+    public function getSalesReport($start = null, $end = null)
+    {
+
+
+        // Set start date
+        if (!$start) {
+            $start = DB::table('sales_transactions')->min('created_at');
+            $start = $start
+                ? Carbon::parse($start)->startOfDay()
+                : Carbon::today()->startOfDay();
+        } else {
+            $start = Carbon::parse($start)->startOfDay();
+        }
+
+        // Set end date
+        $end = $end
+            ? Carbon::parse($end)->endOfDay()
+            : Carbon::today()->endOfDay();
 
 
         $query = SalesTransaction::query();
-         $trend = SalesTransaction::selectRaw('DATE(created_at) as date, SUM(total_amount) as total')
-         ->when($start && $end, function($q) use ($start , $end){
-          $q->whereBetween('created_at',[$start,$end]);
-         })
-         ->groupBy('date')
-         ->orderBy('date')
-         ->get();
+        $trend = SalesTransaction::selectRaw('DATE(created_at) as date, SUM(total_amount) as total')
+            ->when($start && $end, function ($q) use ($start, $end) {
+                $q->whereBetween('created_at', [$start, $end]);
+            })
+            ->groupBy('date')
+            ->orderBy('date')
+            ->get();
 
-      if($start && $end){
-        $query->whereBetween('created_at',[$start,$end]);
-      }
-
-
-     return [
-        'total_sales' => $query->sum('total_amount'),
-        'transactions' => $query->count(),
-        'average_transaction' => round($query->avg('total_amount'),2),
-        'trend' => $trend
-     ];
+        if ($start && $end) {
+            $query->whereBetween('created_at', [$start, $end]);
+        }
 
 
+        return [
+            'total_sales' => $query->sum('total_amount'),
+            'transactions' => $query->count(),
+            'average_transaction' => round($query->avg('total_amount'), 2),
+            'trend' => $trend
+        ];
     }
 
 
-// purchase report 
-    public function getPurchases($start = null, $end = null){
-    $start = $start ?? Carbon::now()->format('Y-m-d');
-    $end = $end ?? Carbon::now()->format('Y-m-d');
+    // purchase report
+    public function getPurchases($start = null, $end = null)
+    {
+        $start = $start ?? Carbon::now()->format('Y-m-d');
+        $end = $end ?? Carbon::now()->format('Y-m-d');
 
-  //  $itemsQuery = PurchaseItem::query(); baka magamit soon
-    $ordersQuery = PurchaseOrder::query();
-    $ordersQuery->whereBetween('created_at',[$start,$end]);
-    $averageOrder = round($ordersQuery->avg('total_amount'),2) ?? 0;
+        //  $itemsQuery = PurchaseItem::query(); baka magamit soon
+        $ordersQuery = PurchaseOrder::query();
+        $ordersQuery->whereBetween('created_at', [$start, $end]);
+        $averageOrder = round($ordersQuery->avg('total_amount'), 2) ?? 0;
 
-    $trend = PurchaseOrder::selectRaw('DATE(created_at) as date, SUM(total_amount)as total')
-    ->when($start && $end, function($x) use($start,$end){ 
-      $x->whereBetween('created_at',[$start,$end]);
-    })
-    ->groupBy('date')
-         ->orderBy('date')
-         ->get();
+        $trend = PurchaseOrder::selectRaw('DATE(created_at) as date, SUM(total_amount)as total')
+            ->when($start && $end, function ($x) use ($start, $end) {
+                $x->whereBetween('created_at', [$start, $end]);
+            })
+            ->groupBy('date')
+            ->orderBy('date')
+            ->get();
 
-    return [
-       'total_purchases' => $ordersQuery->sum('total_amount'),
-       'purchase_orders' => $ordersQuery->count(),
-       'average_orders' => $averageOrder,
-       'trend' => $trend
-    ];
+        return [
+            'total_purchases' => $ordersQuery->sum('total_amount'),
+            'purchase_orders' => $ordersQuery->count(),
+            'average_orders' => $averageOrder,
+            'trend' => $trend
+        ];
     }
 
-//inventory report 
-    public function getInventory($start = null, $end = null){
-         $start = $start ?? Carbon::now()->format('Y-m-d');
-         $end = $end ?? Carbon::now()->format('Y-m-d');
-   // query of product
-         $productsQuery = Product::query();
-  //inventory
-  $inventory = DB::table('inventory');
-// inventory value
-     $totalInventoryValue = $inventory
-          ->join('products','inventory.product_id','=','products.id')
-          ->select(DB::raw('SUM(products.cost_price * inventory.quantity) as total_value'))
-          ->value('total_value');     
+    //inventory report
+    public function getInventory($start = null, $end = null)
+    {
+        $start = $start ?? Carbon::now()->format('Y-m-d');
+        $end = $end ?? Carbon::now()->format('Y-m-d');
+        // query of product
+        $productsQuery = Product::query();
+        //inventory
+        $inventory = DB::table('inventory');
+        // inventory value
+        $totalInventoryValue = $inventory
+            ->join('products', 'inventory.product_id', '=', 'products.id')
+            ->select(DB::raw('SUM(products.cost_price * inventory.quantity) as total_value'))
+            ->value('total_value');
 
-// low stock
- $lowStock = $inventory->where('quantity','<',10)->count();
-// no stock
- $noStock =  $inventory->where('quantity','=', 0)->count();
+        // low stock
+        $lowStock = DB::table('inventory')
+            ->join('products', 'inventory.product_id', '=', 'products.id')
+            ->whereNull('products.deleted_at')
+            ->whereNull('inventory.deleted_at')
+            ->whereColumn('inventory.quantity', '<=', 'products.reorder_level')
+            ->where('inventory.quantity', '>', 0)
+            ->count();
+        // no stock
+        $noStock =  DB::table('inventory')
+            ->whereNull('deleted_at')
+            ->where('quantity', '=', 0)
+            ->count();
 
- //product distribution by category
- $distCategory= DB::table('categories as a')
-    ->join('products as b', 'b.category_id', '=', 'a.id')
-    ->select('a.name', DB::raw('COUNT(b.category_id) as total'))
-    ->groupBy('a.name')
-    ->get();
-// inventory value by category
-  $valCategory = DB::table('categories as a')
-   ->join('products as b', 'b.category_id','=','a.id')
-   ->join('inventory as c', 'c.product_id','=','b.id')
-   ->select('a.name',DB::raw('SUM(c.quantity * b.unit_price) as inventory_value'))
-   ->groupBy('a.name')
-   ->get();
-         return [
-          'total_products' => $productsQuery->count(),
-          'total_value' => $totalInventoryValue,
-           'low_stock' => $lowStock,
-           'out_of_stock' => $noStock,
-           'ditribution_category' => $distCategory,
-           'inventory_value_category' => $valCategory
-         ];
-
+        //product distribution by category
+        $distCategory = DB::table('categories as a')
+            ->join('products as b', 'b.category_id', '=', 'a.id')
+            ->select('a.name', DB::raw('COUNT(b.category_id) as total'))
+            ->groupBy('a.name')
+            ->get();
+        // inventory value by category
+        $valCategory = DB::table('categories as a')
+            ->join('products as b', 'b.category_id', '=', 'a.id')
+            ->join('inventory as c', 'c.product_id', '=', 'b.id')
+            ->select('a.name', DB::raw('SUM(c.quantity * b.unit_price) as inventory_value'))
+            ->groupBy('a.name')
+            ->get();
+        return [
+            'total_products' => $productsQuery->count(),
+            'total_value' => $totalInventoryValue,
+            'low_stock' => $lowStock,
+            'out_of_stock' => $noStock,
+            'ditribution_category' => $distCategory,
+            'inventory_value_category' => $valCategory
+        ];
     }
 
 
     // get Performance
 
-     public function getPerformance($start = null, $end = null){
-     if (!isset($start)) {
-    $start = DB::table('sales_items')->min('created_at'); // returns earliest datetime or null
-    $start = $start ? Carbon::parse($start)->startOfDay() : Carbon::today()->startOfDay();
-     }
+    public function getPerformance($start = null, $end = null)
+    {
+        if (!isset($start)) {
+            $start = DB::table('sales_items')->min('created_at'); // returns earliest datetime or null
+            $start = $start ? Carbon::parse($start)->startOfDay() : Carbon::today()->startOfDay();
+        }
 
-// Kung walang $end, default today
-$end = $end ?? Carbon::today()->endOfDay();
-      $revenueByCategory = DB::table('categories as a')
-      ->leftJoin('products as b' , 'a.id', '=', 'b.category_id')
-      ->leftJoin('sales_items as c', function($join) use ($start,$end){
-        $join->on('b.id','=','c.product_id')
-             ->whereBetween('c.created_at',[$start,$end]);
-      }) ->select(
-        'a.name',
-        DB::raw('COALESCE(SUM(c.unit_price * c.quantity), 0) as total')
-    )
-    ->groupBy('a.name')
-    ->orderBy('a.name')
-    ->get();
- 
-
-   $revenueByBrand = DB::table('brands as a')
-      ->leftJoin('products as b' , 'a.id', '=', 'b.brand_id')
-      ->leftJoin('sales_items as c', function($join) use ($start,$end){
-        $join->on('b.id','=','c.product_id')
-             ->whereBetween('c.created_at',[$start,$end]);
-      }) ->select(
-        'a.name',
-        DB::raw('COALESCE(SUM(c.unit_price * c.quantity), 0) as total')
-    )
-    ->groupBy('a.name')
-    ->orderBy('a.name')
-    ->get();
-
-return [
-  'revenue_by_category' => $revenueByCategory,
-  'revenue_by_brand' => $revenueByBrand
-];
-       
-     }
+        // Kung walang $end, default today
+        $end = $end ?? Carbon::today()->endOfDay();
+        $revenueByCategory = DB::table('categories as a')
+            ->leftJoin('products as b', 'a.id', '=', 'b.category_id')
+            ->leftJoin('sales_items as c', function ($join) use ($start, $end) {
+                $join->on('b.id', '=', 'c.product_id')
+                    ->whereBetween('c.created_at', [$start, $end]);
+            })->select(
+                'a.name',
+                DB::raw('COALESCE(SUM(c.unit_price * c.quantity), 0) as total')
+            )
+            ->groupBy('a.name')
+            ->orderBy('a.name')
+            ->get();
 
 
-public function getStockAdjustments($start = null, $end = null)
-{
-    // Set start date
-    if (!$start) {
-        $start = DB::table('stock_adjustments')->min('created_at');
-        $start = $start
-            ? Carbon::parse($start)->startOfDay()
-            : Carbon::today()->startOfDay();
-    } else {
-        $start = Carbon::parse($start)->startOfDay();
+        $revenueByBrand = DB::table('brands as a')
+            ->leftJoin('products as b', 'a.id', '=', 'b.brand_id')
+            ->leftJoin('sales_items as c', function ($join) use ($start, $end) {
+                $join->on('b.id', '=', 'c.product_id')
+                    ->whereBetween('c.created_at', [$start, $end]);
+            })->select(
+                'a.name',
+                DB::raw('COALESCE(SUM(c.unit_price * c.quantity), 0) as total')
+            )
+            ->groupBy('a.name')
+            ->orderBy('a.name')
+            ->get();
+
+        return [
+            'revenue_by_category' => $revenueByCategory,
+            'revenue_by_brand' => $revenueByBrand
+        ];
     }
 
-    // Set end date
-    $end = $end
-        ? Carbon::parse($end)->endOfDay()
-        : Carbon::today()->endOfDay();
 
-    // Total adjustments count
-    $totalAdjustments = DB::table('stock_adjustments')
-        ->whereBetween('created_at', [$start, $end])
-        ->count();
+    public function getStockAdjustments($start = null, $end = null)
+    {
+        // Set start date
+        if (!$start) {
+            $start = DB::table('stock_adjustments')->min('created_at');
+            $start = $start
+                ? Carbon::parse($start)->startOfDay()
+                : Carbon::today()->startOfDay();
+        } else {
+            $start = Carbon::parse($start)->startOfDay();
+        }
 
-    // Adjustment value
-    $adjustmentValue = DB::table('stock_adjustments as a')
-        ->join('stock_movements as b', 'a.id', '=', 'b.reference_id')
-        ->join('products as c', 'c.id', '=', 'b.product_id')
-        ->where('b.reference_type', 'adjustment')
-        ->whereBetween('a.created_at', [$start, $end])
-        ->select(DB::raw("
+        // Set end date
+        $end = $end
+            ? Carbon::parse($end)->endOfDay()
+            : Carbon::today()->endOfDay();
+
+        // Total adjustments count
+        $totalAdjustments = DB::table('stock_adjustments')
+            ->whereBetween('created_at', [$start, $end])
+            ->count();
+
+        // Adjustment value
+        $adjustmentValue = DB::table('stock_adjustments as a')
+            ->join('stock_movements as b', 'a.id', '=', 'b.reference_id')
+            ->join('products as c', 'c.id', '=', 'b.product_id')
+            ->where('b.reference_type', 'adjustment')
+            ->whereBetween('a.created_at', [$start, $end])
+            ->select(DB::raw("
             SUM(
                 CASE
                     WHEN b.movement_type = 'in' THEN b.quantity * c.cost_price
@@ -214,75 +226,75 @@ public function getStockAdjustments($start = null, $end = null)
                 END
             ) as adjustment_value
         "))
-        ->value('adjustment_value') ?? 0;
+            ->value('adjustment_value') ?? 0;
 
-    // Adjustments by reason
-    $reasonCounts = DB::table('stock_adjustments')
-        ->whereBetween('created_at', [$start, $end])
-        ->select('reason', DB::raw('COUNT(*) as num_reasons'))
-        ->groupBy('reason')
-        ->get();
+        // Adjustments by reason
+        $reasonCounts = DB::table('stock_adjustments')
+            ->whereBetween('created_at', [$start, $end])
+            ->select('reason', DB::raw('COUNT(*) as num_reasons'))
+            ->groupBy('reason')
+            ->get();
 
-    return [
-        'total_adjustments'       => $totalAdjustments,
-        'adjustments_value'       => $adjustmentValue,
-        'adjustments_by_reason'   => $reasonCounts
-    ];
-}
-
-
-public function getProfitLossReport($start = null, $end = null)
-{
-   if (!isset($start)) {
-    $start = DB::table('stock_movements')->min('created_at'); // returns earliest datetime or null
-    $start = $start ? Carbon::parse($start)->startOfDay() : Carbon::today()->startOfDay();
-     }
-// Kung walang $end, default today
-   $end = $end ?? Carbon::today()->endOfDay();
-
-    // Revenue
-    $revenue = SalesTransaction::whereBetween('created_at', [$start, $end])
-        ->sum('total_amount');
-
-    // Cost of goods sold
-    $costOfGoods = DB::table('sales_items as a')
-        ->join('products as b', 'b.id', '=', 'a.product_id')
-        ->whereBetween('a.created_at', [$start, $end])
-        ->select(DB::raw('SUM(a.quantity * b.cost_price) as cost_of_goods'))
-        ->value('cost_of_goods') ?? 0;
-
-    // Gross profit
-    $grossProfit = $revenue - $costOfGoods;
+        return [
+            'total_adjustments'       => $totalAdjustments,
+            'adjustments_value'       => $adjustmentValue,
+            'adjustments_by_reason'   => $reasonCounts
+        ];
+    }
 
 
+    public function getProfitLossReport($start = null, $end = null)
+    {
+        if (!isset($start)) {
+            $start = DB::table('stock_movements')->min('created_at'); // returns earliest datetime or null
+            $start = $start ? Carbon::parse($start)->startOfDay() : Carbon::today()->startOfDay();
+        }
+        // Kung walang $end, default today
+        $end = $end ?? Carbon::today()->endOfDay();
 
-$adjustmentLoss = DB::table('stock_adjustments as a')
-->join('stock_movements as b', 'a.id', '=', 'b.reference_id') 
-->join('products as c', 'c.id', '=', 'b.product_id') ->where('reference_type', 'adjustment') 
-->where('movement_type', 'out')  ->whereBetween('a.created_at', [$start, $end])->select(DB::raw('SUM(b.quantity * c.cost_price) as total_cost')) 
-->value('total_cost') ?? 0;
-        
-    // Net profit
-    $netProfit = $grossProfit - $adjustmentLoss;
+        // Revenue
+        $revenue = SalesTransaction::whereBetween('created_at', [$start, $end])
+            ->sum('total_amount');
 
-    // Profit margin (%)
-    $profitMargin = $revenue > 0
-        ? round(($netProfit / $revenue) * 100, 2)
-        : 0;
+        // Cost of goods sold
+        $costOfGoods = DB::table('sales_items as a')
+            ->join('products as b', 'b.id', '=', 'a.product_id')
+            ->whereBetween('a.created_at', [$start, $end])
+            ->select(DB::raw('SUM(a.quantity * b.cost_price) as cost_of_goods'))
+            ->value('cost_of_goods') ?? 0;
 
-    return [
-    
-        'revenue'         => $revenue,
-        'cost_of_goods'   => $costOfGoods,
-        'gross_profit'    => $grossProfit,
-        'adjustment_loss' => $adjustmentLoss,
-        'net_profit'      => $netProfit,
-        'profit_margin'   => $profitMargin,
-    ];
-}
+        // Gross profit
+        $grossProfit = $revenue - $costOfGoods;
 
 
-public function getReportCSV($start, $end, $type)
+
+        $adjustmentLoss = DB::table('stock_adjustments as a')
+            ->join('stock_movements as b', 'a.id', '=', 'b.reference_id')
+            ->join('products as c', 'c.id', '=', 'b.product_id')->where('reference_type', 'adjustment')
+            ->where('movement_type', 'out')->whereBetween('a.created_at', [$start, $end])->select(DB::raw('SUM(b.quantity * c.cost_price) as total_cost'))
+            ->value('total_cost') ?? 0;
+
+        // Net profit
+        $netProfit = $grossProfit - $adjustmentLoss;
+
+        // Profit margin (%)
+        $profitMargin = $revenue > 0
+            ? round(($netProfit / $revenue) * 100, 2)
+            : 0;
+
+        return [
+
+            'revenue'         => $revenue,
+            'cost_of_goods'   => $costOfGoods,
+            'gross_profit'    => $grossProfit,
+            'adjustment_loss' => $adjustmentLoss,
+            'net_profit'      => $netProfit,
+            'profit_margin'   => $profitMargin,
+        ];
+    }
+
+
+    public function getReportCSV($start, $end, $type)
     {
         switch ($type) {
             case 'sales':
@@ -305,6 +317,4 @@ public function getReportCSV($start, $end, $type)
                 return $this->reportCSVService->exportProfitAndLoss($data);
         }
     }
-
-
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -242,7 +242,7 @@ Route::get('/test-permissions', function () {
                     Route::middleware('modules:Settings')->group(function () {
                         Route::get('/', [SystemSettingController::class, 'index'])->middleware('permissions:View');
                         Route::patch('/', [SystemSettingController::class, 'update'])->middleware('permissions:Edit');
-                        
+
                         // Backup & Restore (Superadmin only)
                         Route::middleware('role:superadmin')->group(function () {
                             Route::get('/backup', [SystemSettingController::class, 'backup']);


### PR DESCRIPTION
# What's new in this PR

### Quick Setup
- No additional migrations or environment changes are required.
- Ensure the `products` table has valid `reorder_level` values (default is 10).

### TL;DR
Updated low stock calculation to use product-specific `reorder_level` and excluded out-of-stock items from the count.

### Summary
Previously, the system flagged items as "low stock" if their quantity was less than 10, regardless of the product type. This PR refactors the logic in both `DashboardService` and `ReportsService` to use the `reorder_level` defined in the `products` table. Additionally, it ensures that products with exactly 0 quantity are only counted as "Out of Stock" and not as "Low Stock".

### Key Features
- **Dynamic Low Stock Threshold:** Uses `products.reorder_level` instead of a hardcoded value.
- **Accurate Statistics:** Products with 0 quantity are now strictly categorized as Out of Stock, preventing duplicated alerts in the "Low Stock" category.
- **Data Integrity:** Added checks for soft-deleted products to ensure they don't appear in dashboard or report statistics.

### Technical Changes
- **app/Services/DashboardService.php**:
    - Updated `getStats()` to join `inventory` with `products`.
    - Changed low stock condition to `inventory.quantity <= products.reorder_level AND inventory.quantity > 0`.
- **app/Services/ReportsService.php**:
    - Updated `getInventory()` to perform a join with the `products` table.
    - Standardized the low stock query to match the Dashboard's logic.

### Checklist
- [x] Verified `DashboardService` stats calculation.
- [x] Verified `ReportsService` inventory report calculation.
- [x] Confirmed soft deletes are handled.
- [x] Confirmed `quantity > 0` constraint for low stock logic.
