### PR TITLE
feat: add location field to inventory table

### DIFF
--- a/app/Http/Requests/InventoryRequest.php
+++ b/app/Http/Requests/InventoryRequest.php
@@ -25,6 +25,7 @@ class InventoryRequest extends FormRequest
             'product_id' => 'required|exists:products,id',
             'supplier_id' => 'required|exists:suppliers,id',
             'quantity' => 'required|integer|min:0',
+            'location' => 'nullable|string|max:255',
             'last_stock_in' => 'nullable|date',
         ];
 

--- a/app/Http/Resources/InventoryResource.php
+++ b/app/Http/Resources/InventoryResource.php
@@ -21,6 +21,7 @@ class InventoryResource extends JsonResource
             'category' => $this->product?->category?->name,
             'brand' =>  $this->product?->brand?->name,
             'quantity' => $this->quantity,
+            'location' => $this->location,
             'last_stock_in' => $this->last_stock_in,
         ];
     }

--- a/app/Models/Inventory.php
+++ b/app/Models/Inventory.php
@@ -26,6 +26,7 @@ class Inventory extends Model
         'product_id',
         'supplier_id',
         'quantity',
+        'location',
         'last_stock_in',
     ];
 

--- a/database/migrations/2026_01_27_052308_add_location_to_inventory_table.php
+++ b/database/migrations/2026_01_27_052308_add_location_to_inventory_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('inventory', function (Blueprint $table) {
+            $table->string('location')->nullable()->after('quantity');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('inventory', function (Blueprint $table) {
+            $table->dropColumn('location');
+        });
+    }
+};


### PR DESCRIPTION
closes: #118 

# What's new in this PR

### Quick Setup
(Backend)
```bash
php artisan migrate
```

### TL;DR
Added a `location` column to the `inventory` table to allow tracking of physical storage locations (e.g., Aisle, Shelf) via the API.

### Summary
This PR implements the requested feature to track the physical location of inventory items. By adding a `location` field to the inventory records, staff can now specify and retrieve where an item is stored within the warehouse or shop. This change touches the database layer, model definition, request validation, and API transformation.

### Key Features
- **Storage Location Tracking:** Ability to save a text-based location (e.g., "Aisle 5, Bin C") for each inventory item.
- **API Exposure:** The `location` field is now available in Inventory list and detail endpoints.
- **Validation:** Ensures the location, if provided, is a valid string.

### Technical Changes
- **Database:** Created migration `2026_01_27_052308_add_location_to_inventory_table.php` adding a nullable `string` column `location` after `quantity`.
- **Model:** Updated `App\Models\Inventory` to include `location` in the `$fillable` array.
- **Request:** Updated `App\Http\Requests\InventoryRequest` to include validation rules: `nullable|string|max:255`.
- **Resource:** Updated `App\Http\Resources\InventoryResource` to include the `location` field in the API response.

### Checklist
- [x] Database migration created and executed successfully.
- [x] `Inventory` model updated with mass assignment protection.
- [x] API Request validation rules implemented.
- [x] API Resource updated to return the new field.
