### PR TITLE
update products bug error done

### DIFF
--- a/app/Http/Controllers/API/ProductController.php
+++ b/app/Http/Controllers/API/ProductController.php
@@ -8,6 +8,7 @@ use Illuminate\Http\Request;
 use App\Http\Resources\ProductResource;
 use App\Http\Resources\ProductAttributeResource;
 use App\Http\Requests\Product\ProductRequest;
+use App\Http\Requests\Product\ProductUpdateRequest;
 use App\Http\Requests\Product\ProductAttributeRequest;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Symfony\Component\HttpFoundation\StreamedResponse;
@@ -120,7 +121,7 @@ class ProductController
 
 
 //update product
-      public function update(ProductRequest $request, $id){
+      public function update(ProductUpdateRequest $request, $id){
      
               
       try{

--- a/app/Http/Requests/Product/ProductUpdateRequest.php
+++ b/app/Http/Requests/Product/ProductUpdateRequest.php
@@ -4,7 +4,7 @@ namespace App\Http\Requests\Product;
 
 use Illuminate\Foundation\Http\FormRequest;
 
-class ProductRequest extends FormRequest
+class ProductUpdateRequest extends FormRequest
 {
     /**
      * Determine if the user is authorized to make this request.
@@ -21,12 +21,9 @@ class ProductRequest extends FormRequest
      */
     public function rules(): array
     {
-
-        $id = $this->route('id');
         return [
              'category_id' => 'required',
              'brand_id' => 'required',
-             'sku' => 'required|unique:products,sku',
              'name' => 'required',
              'description' => 'sometimes',
              'unit_price' => 'required',


### PR DESCRIPTION
# PR TITLE: Fix: Product update validation error

## What's new in this PR

### Quick Setup

No special setup is required.

### TL;DR

This PR fixes a validation error that occurred when updating a product without changing its SKU. A new `ProductUpdateRequest` has been created to handle validation for product updates, removing the `unique` rule for the `sku` field.

### Summary

When updating a product, the system would throw a validation error if the SKU was not changed, as the `sku` field was required to be unique. This PR resolves this issue by introducing a dedicated `ProductUpdateRequest` for the update operation. This new request class omits the `unique` validation rule for the `sku`, allowing for seamless updates to other product attributes.

### Key Features

- **Fix Product Update Validation:** Resolves the "SKU already exists" error when updating product details.

### Technical Changes

- **Created `app/Http/Requests/Product/ProductUpdateRequest.php`:** A new form request class for handling product update validation. This class does not enforce a unique SKU.
- **Modified `app/Http/Controllers/API/ProductController.php`:** The `update` method now uses `ProductUpdateRequest` instead of `ProductRequest`.
- **Modified `app/Http/Requests/Product/ProductRequest.php`:** No changes, but this is related to the issue.

### Checklist

- [x] Code follows coding standards.
- [x] New features are covered by tests. (No new feature, it's a bug fix)
- [x] No sensitive information exposed.

